### PR TITLE
Allowed %s in spec-announcer (and thus more flexible spec-naming)

### DIFF
--- a/lib/test-jumper-leap.coffee
+++ b/lib/test-jumper-leap.coffee
@@ -1,5 +1,6 @@
 #_ = require 'underscore'
-FS = require('fs');
+FS = require('fs')
+PATH = require('path')
 
 module.exports =
   class TestJumperLeap
@@ -9,40 +10,68 @@ module.exports =
     getCurrentFilePath: ->
       atom.project.relativize(atom.workspace.activePaneItem.getUri())
 
-    currentPathIsSpec: ->
-      /spec\./.test(@getCurrentFilePath())
+    filenameIsSpec: (filename) ->
+      spec_announcer = atom.config.get('test-jumper.spec-announcer')
+
+      @constructor._matchFormat(spec_announcer,filename)
 
     leap: ->
       return unless atom.workspace.getActiveEditor()
 
-      for target in @getMovementTarget()
-        filename = /(.*?)\.+/.exec(atom.workspace.activePaneItem.getTitle())[1]
-        if @currentPathIsSpec()
-          target_filename = filename.replace atom.config.get('test-jumper.spec-announcer'), ''
+      spec_announcer = atom.config.get('test-jumper.spec-announcer')
+      currentFilePath = @getCurrentFilePath()
+      filename = PATH.basename(currentFilePath)
+
+      for target in @getMovementTargetForFilePath(currentFilePath)
+        if @filenameIsSpec(filename)
+          target_filename = @constructor._unformat(spec_announcer,filename)
         else
-          target_filename = filename + atom.config.get('test-jumper.spec-announcer')
+          target_filename = @constructor._format(spec_announcer,filename)
 
         t = target[1]
         openthis = t.replace(filename, target_filename)
-        openthis = atom.project.getRootDirectory().path + "/" + openthis
+        openthis = PATH.join(atom.project.getRootDirectory().path,openthis)
 
         if FS.existsSync openthis
-            atom.workspace.open(openthis)
+          atom.workspace.open(openthis)
 
 
-    getMovementTarget: ->
-      replace_targets = @getMovementRules().filter (r) =>
-        (new RegExp("^#{r[0]}")).test(@getCurrentFilePath())
 
-      replace_targets.map (target) =>
-        [@getCurrentFilePath(), @getCurrentFilePath().replace (new RegExp("^#{target[0]}")), target[1]]
+    getMovementTargetForFilePath: (filePath) ->
+      replace_targets = @getMovementRulesForFilePath(filePath).filter (r) ->
+        (new RegExp("^#{r[0]}")).test(filePath)
 
-    getMovementRules: ->
+      replace_targets.map (target) ->
+        [filePath, filePath.replace (new RegExp("^#{target[0]}")), target[1]]
+
+    getMovementRulesForFilePath: (filePath) ->
       targets = atom.config.get('test-jumper.locations').map (location) ->
         location.split('|')
 
-      if @currentPathIsSpec()
+      filename = PATH.basename(filePath)
+
+      if @filenameIsSpec(filename)
         return targets.map (t) ->
           [t[1],t[0]]
       else
         return targets
+
+
+    # A very simple implementation of UTIL.format
+    # Only supports one '%s'
+    @_format: (format, replacement) ->
+      replaced_string = format.replace(/^(.*)%s(.*)$/,"$1#{replacement}$2")
+      replaced_string = replacement + format if format == replaced_string # legacy support
+      return replaced_string
+
+    # The inverse of @_format
+    # Only supports one '%s'
+    @_unformat: (format, formatted_string) ->
+      format_parts = format.split(/%s/)
+      format_parts.unshift '' if format_parts.length == 1 # legacy support
+      formatted_string.replace(new RegExp("^#{format_parts[0]}(.*)#{format_parts[1]}$"),'$1')
+
+    # returns true if the formatted_string was created using format
+    # Only supports one '%s'
+    @_matchFormat: (format, formatted_string) ->
+      return @_unformat(format, formatted_string) != formatted_string

--- a/lib/test-jumper-leap.coffee
+++ b/lib/test-jumper-leap.coffee
@@ -13,6 +13,8 @@ module.exports =
     filenameIsSpec: (filename) ->
       spec_announcer = atom.config.get('test-jumper.spec-announcer')
 
+      filename = @constructor._extensionFreeBasename(filename)
+
       @constructor._matchFormat(spec_announcer,filename)
 
     leap: ->
@@ -20,7 +22,7 @@ module.exports =
 
       spec_announcer = atom.config.get('test-jumper.spec-announcer')
       currentFilePath = @getCurrentFilePath()
-      filename = PATH.basename(currentFilePath)
+      filename = @constructor._extensionFreeBasename(currentFilePath)
 
       for target in @getMovementTargetForFilePath(currentFilePath)
         if @filenameIsSpec(filename)
@@ -48,9 +50,7 @@ module.exports =
       targets = atom.config.get('test-jumper.locations').map (location) ->
         location.split('|')
 
-      filename = PATH.basename(filePath)
-
-      if @filenameIsSpec(filename)
+      if @filenameIsSpec(filePath)
         return targets.map (t) ->
           [t[1],t[0]]
       else
@@ -75,3 +75,7 @@ module.exports =
     # Only supports one '%s'
     @_matchFormat: (format, formatted_string) ->
       return @_unformat(format, formatted_string) != formatted_string
+
+    @_extensionFreeBasename: (file_path) ->
+      file_name = PATH.basename(file_path)
+      return file_name.replace(/^([^\.]+).*$/,'$1')

--- a/lib/test-jumper.coffee
+++ b/lib/test-jumper.coffee
@@ -2,7 +2,7 @@ TestJumperLeap = require './test-jumper-leap'
 
 module.exports =
 
-  configDefaults:
+  config:
     'locations':
       type: 'array'
       default: [

--- a/lib/test-jumper.coffee
+++ b/lib/test-jumper.coffee
@@ -18,6 +18,24 @@ module.exports =
       description: 'The name of the testfile, whereas "%s" gets replaced by the original filename.'
       type: 'string'
       default: '%s-spec'
+    'x-create-files':
+      type: 'object'
+      properties:
+        'enabled':
+          title: 'Create missing files'
+          description: 'If an expected file is missing, it is automatically created.'
+          type: 'boolean'
+          default: false
+        'source-template':
+          title: 'Source file template'
+          description: 'The default content of a generated source file. "%s" gets replaced by the file name.'
+          type: 'string'
+          default: '# %s\\n#\\n'
+        'spec-template':
+          title: 'Test file template'
+          description: 'The default content of a generated test file. "%s" gets replaced by the file name.'
+          type: 'string'
+          default: '# Specification of %s\\n#\\n'
 
 
   activate: (state) ->

--- a/lib/test-jumper.coffee
+++ b/lib/test-jumper.coffee
@@ -3,11 +3,17 @@ TestJumperLeap = require './test-jumper-leap'
 module.exports =
 
   configDefaults:
-    "locations": [
-     'lib|spec'
-     'app|spec'
-    ]
-    "spec-announcer": '-spec'
+    'locations':
+      type: 'array'
+      default: [
+         'lib|spec'
+         'app|spec'
+        ]
+      items:
+        type: 'string'
+    'spec-announcer':
+      type: 'string'
+      default: '%s-spec'
 
   activate: (state) ->
     atom.workspaceView.command "test-jumper:jump", => @jump()

--- a/lib/test-jumper.coffee
+++ b/lib/test-jumper.coffee
@@ -4,6 +4,8 @@ module.exports =
 
   config:
     'locations':
+      title: 'Source and Test Locations'
+      description: 'A comma-separated list of source-/test-directory pairs. Each pair is separated by a pipe (|) symbol.'
       type: 'array'
       default: [
          'lib|spec'
@@ -12,11 +14,15 @@ module.exports =
       items:
         type: 'string'
     'spec-announcer':
+      title: 'Test-Filename'
+      description: 'The name of the testfile, whereas "%s" gets replaced by the original filename.'
       type: 'string'
       default: '%s-spec'
 
+
   activate: (state) ->
-    atom.workspaceView.command "test-jumper:jump", => @jump()
+    atom.commands.add 'atom-text-editor',
+      "test-jumper:jump", => @jump()
 
   jump: ->
     leaper = new TestJumperLeap

--- a/spec/test-jumper-leap-spec.coffee
+++ b/spec/test-jumper-leap-spec.coffee
@@ -37,3 +37,89 @@ describe "TestJumperLeap", ->
       '/object.js.coffee'
 
     expect(@leaper.currentPathIsSpec()).toBe(false);
+
+
+  describe '@_format', ->
+
+    it 'replaces the %s within the string', ->
+      replaced_string = TestJumperLeap._format('test-%s-spec','file')
+      expect(replaced_string).toBe('test-file-spec')
+
+    it 'replaces the %s at the beginning with a string', ->
+      replaced_string = TestJumperLeap._format('%s-spec','file')
+      expect(replaced_string).toBe('file-spec')
+
+    it 'replaces the %s at the end with a string', ->
+      replaced_string = TestJumperLeap._format('test-%s','file')
+      expect(replaced_string).toBe('test-file')
+
+    # legacy support
+    it 'without %s in format string, the format is appended', ->
+      replaced_string = TestJumperLeap._format('-spec','file')
+      expect(replaced_string).toBe('file-spec')
+
+
+  describe '@_unformat', ->
+
+    it 'works with the %s within the format string', ->
+      replaced_string = TestJumperLeap._unformat('test-%s-spec','test-file-spec')
+      expect(replaced_string).toBe('file')
+
+    it 'works with the %s within the format string', ->
+      replaced_string = TestJumperLeap._unformat('%s-spec','bla-spec')
+      expect(replaced_string).toBe('bla')
+
+    it 'works with the %s within the format string', ->
+      replaced_string = TestJumperLeap._unformat('test-%s','test-blubb')
+      expect(replaced_string).toBe('blubb')
+
+    it 'returns the formatted string, if the format does not match', ->
+      replaced_string = TestJumperLeap._unformat('test-%s','blubb-spec')
+      expect(replaced_string).toBe('blubb-spec')
+
+    it 'returns the formatted string, if the format does not match in the beginning', ->
+      replaced_string = TestJumperLeap._unformat('test-%s-bla','file-xyz-bla')
+      expect(replaced_string).toBe('file-xyz-bla')
+
+    it 'returns the formatted string, if the format does not match in the end', ->
+      replaced_string = TestJumperLeap._unformat('test-%s-bla','test-spec')
+      expect(replaced_string).toBe('test-spec')
+
+
+    # legacy support
+    it 'works without the %s within the format string', ->
+      replaced_string = TestJumperLeap._unformat('-spec','foo-spec')
+      expect(replaced_string).toBe('foo')
+
+
+  describe '@_matchFormat', ->
+
+    it 'works with the %s within the format string', ->
+      test = TestJumperLeap._matchFormat('test-%s-spec','test-file-spec')
+      expect(test).toBe(true)
+
+    it 'works with the %s within the format string', ->
+      test = TestJumperLeap._matchFormat('%s-spec','bla-spec')
+      expect(test).toBe(true)
+
+    it 'works with the %s within the format string', ->
+      test = TestJumperLeap._matchFormat('test-%s','test-blubb')
+      expect(test).toBe(true)
+
+    it 'returns false, if the format does not match', ->
+      test = TestJumperLeap._matchFormat('test-%s','blubb-spec')
+      expect(test).toBe(false)
+
+    it 'returns false, if the format does not match in the beginning', ->
+      test = TestJumperLeap._matchFormat('test-%s-bla','file-xyz-bla')
+      expect(test).toBe(false)
+
+    it 'returns false, if the format does not match in the end', ->
+      test = TestJumperLeap._matchFormat('test-%s-bla','test-spec')
+      expect(test).toBe(false)
+
+
+    # legacy support
+    it 'works without the %s within the format string', ->
+      test = TestJumperLeap._matchFormat('-spec','foo-spec')
+      expect(test).toBe(true)

--- a/spec/test-jumper-leap-spec.coffee
+++ b/spec/test-jumper-leap-spec.coffee
@@ -1,7 +1,5 @@
 TestJumper = require '../lib/test-jumper'
 TestJumperLeap = require '../lib/test-jumper-leap'
-{WorkspaceView} = require 'atom'
-
 
 # Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
 #
@@ -12,31 +10,25 @@ describe "TestJumperLeap", ->
   activationPromise = null
 
   beforeEach =>
-    atom.workspaceView = new WorkspaceView
+    spyOn(atom.config, "get").andCallFake (prop) ->
+      prop = prop.replace('test-jumper.','')
+      TestJumper.config[prop].default
+
     @leaper = new TestJumperLeap
 
 
   it "is able to get the placement target for a bit of code", =>
-    spyOn(@leaper, "getCurrentFilePath").andCallFake ->
-      'lib/object.js.coffee'
-
-    expect(@leaper.getMovementTarget()[0][0]).toBe('lib/object.js.coffee')
+    expect(@leaper.getMovementTargetForFilePath('lib/object.js.coffee')[0][0]).toBe('lib/object.js.coffee')
 
 
   it "knows if the current file is a spec", =>
 
-    spyOn(@leaper, "getCurrentFilePath").andCallFake ->
-      '/object-spec.js.coffee'
-
-    expect(@leaper.currentPathIsSpec()).toBe(true);
+    expect(@leaper.filenameIsSpec('/object-spec.js.coffee')).toBe(true);
 
 
-  it "knows if the current file is nt a spec", =>
+  it "knows if the current file is not a spec", =>
 
-    spyOn(@leaper, "getCurrentFilePath").andCallFake ->
-      '/object.js.coffee'
-
-    expect(@leaper.currentPathIsSpec()).toBe(false);
+    expect(@leaper.filenameIsSpec('/object.js.coffee')).toBe(false);
 
 
   describe '@_format', ->
@@ -123,3 +115,17 @@ describe "TestJumperLeap", ->
     it 'works without the %s within the format string', ->
       test = TestJumperLeap._matchFormat('-spec','foo-spec')
       expect(test).toBe(true)
+
+  describe '@_extensionFreeBasename', ->
+
+    it 'works with one extension', ->
+      name = TestJumperLeap._extensionFreeBasename('lib/blubber.xyz')
+      expect(name).toBe('blubber')
+
+    it 'works with several extensions', ->
+      name = TestJumperLeap._extensionFreeBasename('specs/modules/foo.js.xyz')
+      expect(name).toBe('foo')
+
+    it 'works without extensions', ->
+      name = TestJumperLeap._extensionFreeBasename('src/bar')
+      expect(name).toBe('bar')


### PR DESCRIPTION
Had to change quite a bit in the code (since before, it really only worked with the default value, due to the definition of `currentPathIsSpec`