### PR TITLE
Open the test if it's in a different pane

### DIFF
--- a/lib/test-jumper-leap.coffee
+++ b/lib/test-jumper-leap.coffee
@@ -36,7 +36,7 @@ module.exports =
         openthis = PATH.join(atom.project.getRootDirectory().path,openthis)
 
         if FS.existsSync openthis
-          atom.workspace.open(openthis)
+          atom.workspace.open(openthis, searchAllPanes: true)
 
         else if atom.config.get('test-jumper.x-create-files.enabled')
           src_filename = if is_spec


### PR DESCRIPTION
Closes #2 

This way if the test is over in your right pane, it'll jump to it instead of just opening a new copy where you are..