### PR TITLE
Search AND pop open panes

### DIFF
--- a/lib/test-jumper-leap.coffee
+++ b/lib/test-jumper-leap.coffee
@@ -36,7 +36,15 @@ module.exports =
         openthis = PATH.join(atom.project.getRootDirectory().path,openthis)
 
         if FS.existsSync openthis
-          atom.workspace.open(openthis)
+          split_side = if is_spec
+            'left'
+          else
+            'right'
+
+          open_options =
+            searchAllPanes: true
+          open_options['split'] = split_side if atom.config.get('test-jumper.spec_to_the_right')
+          atom.workspace.open(openthis, open_options)
 
         else if atom.config.get('test-jumper.x-create-files.enabled')
           src_filename = if is_spec

--- a/lib/test-jumper.coffee
+++ b/lib/test-jumper.coffee
@@ -18,6 +18,10 @@ module.exports =
       description: 'The name of the testfile, whereas "%s" gets replaced by the original filename.'
       type: 'string'
       default: '%s-spec'
+    'spec_to_the_right':
+      title: "Check this if you want opening a spec to pop open a panel to the right."
+      type: 'boolean'
+      default: 'false'
     'x-create-files':
       type: 'object'
       properties:


### PR DESCRIPTION
This includes the content #7, but also adds an option that will force an unopened-spec to open over in the right pane #3 